### PR TITLE
Update Trivia Quiz runtime to 49

### DIFF
--- a/io.github.nokse22.trivia-quiz.json
+++ b/io.github.nokse22.trivia-quiz.json
@@ -19,6 +19,8 @@
         "/share/gtk-doc",
         "/share/man",
         "/share/pkgconfig",
+        "*.pyc",
+        "__pycache__",
         "*.la",
         "*.a"
     ],

--- a/io.github.nokse22.trivia-quiz.json
+++ b/io.github.nokse22.trivia-quiz.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nokse22.trivia-quiz",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "trivia-quiz",
     "finish-args" : [


### PR DESCRIPTION
This PR also contains a commit that reduces flatpak size from 2.5 MB to 1.5 MB.